### PR TITLE
Adds wp-content config option for autoloading.

### DIFF
--- a/0-loader.php
+++ b/0-loader.php
@@ -12,10 +12,14 @@
 namespace Roots\Bedrock;
 
 if(!defined('LL_AUTOLOAD_DIR')){
-    if(!defined('LL_AUTOLOAD_USE_CHILD') || constant('LL_AUTOLOAD_USE_CHILD') == false){
-        define('LL_AUTOLOAD_DIR', get_template_directory());
+    if(!defined('LL_AUTOLOAD_CONTENT_DIR') || constant('LL_AUTOLOAD_CONTENT_DIR') === true){
+        define('LL_AUTOLOAD_DIR', realpath(__DIR__.'/../'));
     }else{
-        define('LL_AUTOLOAD_DIR', get_stylesheet_directory());
+        if(!defined('LL_AUTOLOAD_USE_CHILD') || constant('LL_AUTOLOAD_USE_CHILD') == false){
+            define('LL_AUTOLOAD_DIR', get_template_directory());
+        }else{
+            define('LL_AUTOLOAD_DIR', get_stylesheet_directory());
+        }
     }
 }
 


### PR DESCRIPTION
In case a project is instantiated from the wp-content directory, we want to load the vendor and pre/post-autoload files from that directory. This new option `LL_AUTOLOAD_CONTENT_DIR` allows this to happen.