### PR TITLE
Makes the wp-content directory default.

### DIFF
--- a/0-loader.php
+++ b/0-loader.php
@@ -26,7 +26,12 @@ function determine_autoload_dir(){
         return constant('LL_AUTOLOAD_DIR');
     }
     
-    define('LL_AUTOLOAD_DIR', get_template_directory());
+    if(defined('LL_AUTOLOAD_USE_PARENT') && constant('LL_AUTOLOAD_USE_PARENT') === true){
+        define('LL_AUTOLOAD_DIR', get_template_directory());
+        return constant('LL_AUTOLOAD_DIR');
+    }
+
+    define('LL_AUTOLOAD_DIR', realpath(__DIR__.'/../'));
     return constant('LL_AUTOLOAD_DIR');
 }
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ When `0-loader.php` is inserted into the `mu-plugins` directory it will load all
 
 You have multiple options to manipulate where the Plugin Loader will look for a vendor folder. Define one of the following values in wp-config:
 
-### 1. Default == Main / parent theme
-If you define **nothing** it will load search in the main / parent theme via `get_template_directory()`.
+### 1. Default == wp-content directory
+If you define **nothing** it will load the same as 2. `wp-content` directory.
 
 ### 2. wp-content directory
 
@@ -24,7 +24,14 @@ Use the current Child theme via `get_stylesheet_directory` as the theme folder c
 define('LL_AUTOLOAD_USE_CHILD', true);
 ```
 
-### 4. Custom path
+### 4. Parent/default theme
+Use the current parent theme via `get_template_directory` as the theme folder containing the vendor folder. This is only used when no `LL_AUTOLOAD_DIR` is set.
+
+```
+define('LL_AUTOLOAD_USE_PARENT', true);
+```
+
+### 5. Custom path
 Use a specific directory. The script will still append `/vendor/autoload.php` to this path.
 
 ```
@@ -35,10 +42,11 @@ define('LL_AUTOLOAD_DIR', '/path/to/wordpress/theme/');
 
 | **Setting**                                  | **Result**                         |
 |----------------------------------------------|------------------------------------|
-| Nothing                                      | Template directory (parent theme)  |
+| Nothing                                      | wp-content directory               |
 | `define( 'LL_AUTOLOAD_DIR', '/tmp/' );`      | `/tmp/`                            |
 | `define( 'LL_AUTOLOAD_CONTENT_DIR', true );` | wp-content directory               |
-| `define( 'LL_AUTOLOAD_USE_CHILD', true )`    | Stylesheet directory (child theme) |
+| `define( 'LL_AUTOLOAD_USE_CHILD', true );`   | Stylesheet directory (child theme) |
+| `define( 'LL_AUTOLOAD_USE_PARENT', true );`  | Template directory (parent theme)  |
 
 ## Pre and Post autoload
 
@@ -53,3 +61,6 @@ Right after the vendor autoload file is loaded, but before the `mu-plugins` are 
 This file can be used to bootstrap/configure mu-plugin loaded dependencies, or trigger actions that need to happen as early as possible, but autoloading to be set up. 
 
 Adding logging is an example of this. You probably require the Monolog composer dependency, but want it to be bootstrapped before we load the mu-plugins.
+
+## Upgrading from v2.x to v3.x
+In v3, the `wp-content` directory loads by default, instead of the template directory in v2. To restore behaviour, set `define( 'LL_AUTOLOAD_USE_PARENT', true );` in `wp-config.php`.

--- a/tests/AutoloadFileTest.php
+++ b/tests/AutoloadFileTest.php
@@ -15,13 +15,19 @@ class AutoloadFileTest extends TestCase{
         return array(
             'No definitions set' => array(
                 array(),
-                './template_directory/',
+                realpath( __DIR__ . '/../../' ), // The parent of the 0-loader is two directories up from this file.
             ),
             'Autoload dir predefined' => array(
                 array(
                     'LL_AUTOLOAD_DIR' => '/tmp/'
                 ),
                 '/tmp/',
+            ),
+            'Use parent theme (template directory) autoload' => array(
+                array(
+                    'LL_AUTOLOAD_USE_PARENT' => true,
+                ),
+                './template_directory/',
             ),
             'Use child theme autoload directory' => array(
                 array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in GitHub issues or otherwise. --> 
n/a

## Description
<!--- Describe your changes in detail -->
This makes the `wp-content` directory the default to load. This is not backwards compatible and will be tagged as v3. Users can define `LL_AUTOLOAD_USE_PARENT`, to load the same as in v2. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
See adjusted unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
