### PR TITLE
Check if self::$cache is an array before accessing keys.

### DIFF
--- a/0-loader.php
+++ b/0-loader.php
@@ -181,7 +181,7 @@ class Autoloader
         self::$auto_plugins = get_plugins(self::$relative_path);
         self::$mu_plugins   = get_mu_plugins();
         $plugins            = array_diff_key(self::$auto_plugins, self::$mu_plugins);
-        $rebuild            = !is_array(self::$cache['plugins']);
+        $rebuild            = !is_array(self::$cache) || !is_array(self::$cache['plugins']);
         self::$activated    = ($rebuild) ? $plugins : array_diff_key($plugins, self::$cache['plugins']);
         self::$cache        = array('plugins' => $plugins, 'count' => $this->countPlugins());
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in GitHub issues or otherwise. --> 

## Description
Currently, when starting a site for the first time, a warning appears. This is because the `updateCache()` function checks if `self::$cache['plugins']` is an array, while the actual value of `self::$cache` is null. The warning is solved after 1 pageload, because then the `bedrock_autoloader` option is set and the `$cache` is returned.

## How Has This Been Tested?
1. Delete the `bedrock_autoloader` option with `$ wp option delete bedrock_autoloader`
2. Run `$ wp` and see an warning in the terminal
3. Run `$ wp` again and the warning no longer appears

After this fix, the warning no longer appears on the first site load.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
