### PR TITLE
Fix cached plugins check

### DIFF
--- a/0-loader.php
+++ b/0-loader.php
@@ -181,7 +181,7 @@ class Autoloader
         self::$auto_plugins = get_plugins(self::$relative_path);
         self::$mu_plugins   = get_mu_plugins();
         $plugins            = array_diff_key(self::$auto_plugins, self::$mu_plugins);
-        $rebuild            = !is_array(self::$cache['plugins']);
+        $rebuild            = !isset(self::$cache['plugins']) || !is_array(self::$cache['plugins']);
         self::$activated    = ($rebuild) ? $plugins : array_diff_key($plugins, self::$cache['plugins']);
         self::$cache        = array('plugins' => $plugins, 'count' => $this->countPlugins());
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in GitHub issues or otherwise. --> 
https://app.asana.com/0/0/1202735259015927/f

## Description
<!--- Describe your changes in detail -->
Fixes warning that is output when cache has not been set.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I ran the command as displayed in the screenshot below and the warning is gone.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

![image](https://user-images.githubusercontent.com/50165380/183425813-737de483-7121-419a-ab8e-8e33fbc5c5c5.png)
